### PR TITLE
stage haskell cabal file so direnv works

### DIFF
--- a/src/language/haskell.rs
+++ b/src/language/haskell.rs
@@ -195,6 +195,12 @@ pub(crate) async fn create_haskell_template(
 
     tokio::fs::rename("./template.cabal", format!("./{package_name}.cabal"))
         .await?;
+    tokio::process::Command::new("git")
+	.arg("add")
+	.arg(format!("./{package_name}.cabal"))
+	.spawn()?
+	.wait()
+	.await?;
 
     println!(
         r"


### PR DESCRIPTION
I noticed I have to manually `git add` the new cabal file, so I spent ten minutes reading the source to see how I might fix that.
I dunno if this is the right way, but it appears to work after testing with `nix run github:shapr/templates/stage-cabal-file`

If there's a better way, let me know and I'll improve this pull request.